### PR TITLE
Fixed one broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then find this configuration block in the `kinde-auth.json` file:
 }
 ```
 
-In the configuration block above replace the following placeholders with values from your Kinde [App Keys](https://kinde.com/docs/the-basics/getting-app-keys) page:
+In the configuration block above replace the following placeholders with values from your Kinde [App Keys](https://docs.kinde.com/get-started/connect/getting-app-keys/) page:
 
 - `https://<your_kinde_subdomain>.kinde.com` with the `Token host` value
 - `<your_kinde_client_id` with the `Client ID` value.


### PR DESCRIPTION
There was a broken link in the readme going to old docs address

- [ x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x ] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated URLs for Kinde App Keys documentation for improved accuracy.
	- Corrected a placeholder error in the `clientId` section for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->