### PR TITLE
chore: standardize CODEOWNERS for giants-kinde and sdk-engineers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
 * @kinde-starter-kits/giants-kinde
-
+package-lock.json @kinde-starter-kits/sdk-engineers
+**/package-lock.json @kinde-starter-kits/sdk-engineers
+package.json @kinde-starter-kits/sdk-engineers
+**/package.json @kinde-starter-kits/sdk-engineers
+pnpm-lock.yaml @kinde-starter-kits/sdk-engineers
+**/pnpm-lock.yaml @kinde-starter-kits/sdk-engineers


### PR DESCRIPTION
## Summary
- Set `*` default ownership to `@kinde-starter-kits/giants-kinde`
- Assign `@kinde-starter-kits/sdk-engineers` to npm/pnpm dependency files
- Aligns this repo with the org-wide CODEOWNERS standard used in `react-starter-kit`

## Test plan
- [ ] Verify CODEOWNERS file is present at the expected path
- [ ] Confirm PRs touching `package.json` request review from `sdk-engineers`
- [ ] Confirm other changes request review from `giants-kinde`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation describing the custom fonts supported by the Blockchain Explorer and the fallback behavior when they are unavailable.

- **Developer Experience**
  - Added workspace recommendations and settings for formatting, linting, spell-checking, and TypeScript development.
  - Added streamlined debug and test configurations for local development.

- **Maintenance**
  - Updated ignore rules for temporary and generated files.
  - Added automated workspace tasks to support consistent project checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->